### PR TITLE
Fix signin redirect: redirect to home page instead of quiz page after authentication

### DIFF
--- a/src/quiz_app/routes.py
+++ b/src/quiz_app/routes.py
@@ -136,7 +136,7 @@ def google_auth_callback():
         user_info = OAuthService.authenticate_user(auth_code)
         if user_info:
             logger.info(f"User authenticated successfully: {user_info['email']}")
-            return redirect(url_for('ui.quiz'))
+            return redirect(url_for('ui.index'))
         else:
             logger.error("Authentication failed")
             return redirect(url_for('ui.signin'))


### PR DESCRIPTION
## Changes Made
- Modified OAuth callback route to redirect users to home page (`/`) instead of quiz page (`/quiz`) after successful authentication
- This provides a better user experience by showing the full homepage with user info and navigation options

## Testing
- After signing in with Google, users will now be redirected to the homepage
- Users can then choose to start the free quiz or upgrade to pro from the homepage